### PR TITLE
Manage site permissions for chrome extension

### DIFF
--- a/site-settings-manager/README.md
+++ b/site-settings-manager/README.md
@@ -1,0 +1,30 @@
+# Site Settings Manager (MV3)
+
+Remembers and reapplies site permissions (camera, microphone, geolocation, notifications) per-origin using the Chrome `contentSettings` API.
+
+## Install (unpacked)
+
+1. Open Chrome and navigate to `chrome://extensions`.
+2. Enable "Developer mode" (top-right).
+3. Click "Load unpacked" and select the `/workspace/site-settings-manager` folder.
+4. Pin the extension and open a page like Webex or Teams. Use the popup to Save & Apply.
+
+## What it does
+
+- Lets you save per-origin allow/block rules for camera, microphone, geolocation and notifications.
+- Automatically reapplies saved rules on navigation to matching origins.
+- Opportunistically captures existing allow/block overrides you already set in Chrome when you visit a site and syncs them (
+  if you have Chrome sign-in/sync enabled).
+
+## Permissions
+
+- `contentSettings`: needed to read and set per-site rules.
+- `storage`: saves rules in `chrome.storage.sync` for portability.
+- `tabs` and `<all_urls>` host permissions: needed to detect current tab and apply rules for visited sites.
+
+## Notes and limitations
+
+- The `contentSettings.clear()` API is global per content type and scope; there is no per-pattern clear. This extension avoids calling it automatically to prevent wiping all user rules.
+- There is no API to list all site settings across all sites. The extension captures rules as you visit sites and as you Save them in the popup.
+- Incognito windows are not handled specially. You can add handling using `scope: "incognito_session_only"` if desired.
+- The available `setting` values vary per content type. This extension uses `allow`/`block`, which are supported for the targeted types.

--- a/site-settings-manager/background.js
+++ b/site-settings-manager/background.js
@@ -1,0 +1,190 @@
+/* eslint-disable no-undef */
+
+const SUPPORTED_CONTENT_TYPES = [
+  "camera",
+  "microphone",
+  "geolocation",
+  "notifications"
+];
+
+const STORAGE_KEY = "settingsByOrigin";
+
+function getOriginFromUrl(urlString) {
+  try {
+    const url = new URL(urlString);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return null;
+    }
+    return url.origin;
+  } catch (e) {
+    return null;
+  }
+}
+
+function getPrimaryPatternForOrigin(origin) {
+  return `${origin}/*`;
+}
+
+async function getFromSyncStorage(keys) {
+  return new Promise((resolve) => {
+    chrome.storage.sync.get(keys, (items) => resolve(items));
+  });
+}
+
+async function setInSyncStorage(obj) {
+  return new Promise((resolve) => {
+    chrome.storage.sync.set(obj, () => resolve());
+  });
+}
+
+async function removeFromSyncStorage(key) {
+  return new Promise((resolve) => {
+    chrome.storage.sync.remove(key, () => resolve());
+  });
+}
+
+function getContentSetting(type, primaryUrl) {
+  return new Promise((resolve) => {
+    try {
+      chrome.contentSettings[type].get(
+        { primaryUrl },
+        (details) => {
+          if (chrome.runtime.lastError) {
+            resolve({ error: chrome.runtime.lastError.message });
+          } else {
+            resolve(details);
+          }
+        }
+      );
+    } catch (err) {
+      resolve({ error: String(err) });
+    }
+  });
+}
+
+function setContentSetting(type, primaryPattern, setting) {
+  return new Promise((resolve) => {
+    try {
+      chrome.contentSettings[type].set(
+        { primaryPattern, setting, scope: "regular" },
+        () => {
+          if (chrome.runtime.lastError) {
+            resolve({ error: chrome.runtime.lastError.message });
+          } else {
+            resolve({ ok: true });
+          }
+        }
+      );
+    } catch (err) {
+      resolve({ error: String(err) });
+    }
+  });
+}
+
+function clearContentSetting(type, primaryPattern) {
+  return new Promise((resolve) => {
+    try {
+      chrome.contentSettings[type].clear(
+        { scope: "regular" },
+        () => {
+          // Note: clear() removes all rules for this content type across all patterns in this scope.
+          // There is no per-pattern clear() in this API. We therefore avoid calling clear() casually.
+          // Instead, we only use set() to override to allow/block. We won't call clear() automatically.
+          if (chrome.runtime.lastError) {
+            resolve({ error: chrome.runtime.lastError.message });
+          } else {
+            resolve({ ok: true });
+          }
+        }
+      );
+    } catch (err) {
+      resolve({ error: String(err) });
+    }
+  });
+}
+
+async function applySavedSettingsForOrigin(origin) {
+  const pattern = getPrimaryPatternForOrigin(origin);
+  const stored = await getFromSyncStorage([STORAGE_KEY]);
+  const settingsByOrigin = stored[STORAGE_KEY] || {};
+  const saved = settingsByOrigin[origin];
+  if (!saved) return;
+
+  for (const type of SUPPORTED_CONTENT_TYPES) {
+    const desired = saved[type];
+    if (!desired) continue;
+    if (desired === "clear") {
+      // Avoid global clear; skip to prevent wiping all user rules.
+      // Users can manage clearing via the popup for now (we won't implement global clear here).
+      continue;
+    }
+    await setContentSetting(type, pattern, desired);
+  }
+}
+
+async function captureCurrentOverridesForOrigin(origin, url) {
+  const stored = await getFromSyncStorage([STORAGE_KEY]);
+  const settingsByOrigin = stored[STORAGE_KEY] || {};
+  const existing = settingsByOrigin[origin] || {};
+
+  let changed = false;
+
+  for (const type of SUPPORTED_CONTENT_TYPES) {
+    const details = await getContentSetting(type, url);
+    if (details && !details.error) {
+      const setting = details.setting;
+      // Persist only explicit allow/block overrides
+      if (setting === "allow" || setting === "block") {
+        if (existing[type] !== setting) {
+          existing[type] = setting;
+          changed = true;
+        }
+      }
+    }
+  }
+
+  if (changed) {
+    settingsByOrigin[origin] = existing;
+    await setInSyncStorage({ [STORAGE_KEY]: settingsByOrigin });
+  }
+}
+
+async function handleTabUrl(url) {
+  const origin = getOriginFromUrl(url);
+  if (!origin) return;
+
+  // Apply any saved settings for this origin
+  await applySavedSettingsForOrigin(origin);
+
+  // Opportunistically capture current overrides for this origin
+  await captureCurrentOverridesForOrigin(origin, url);
+}
+
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (changeInfo.status === "complete" && tab?.url) {
+    handleTabUrl(tab.url);
+  }
+});
+
+chrome.tabs.onActivated.addListener(async (activeInfo) => {
+  try {
+    const tab = await new Promise((resolve) => {
+      chrome.tabs.get(activeInfo.tabId, resolve);
+    });
+    if (tab?.url) {
+      handleTabUrl(tab.url);
+    }
+  } catch (e) {
+    // ignore
+  }
+});
+
+chrome.runtime.onInstalled.addListener(async () => {
+  // Optionally apply saved settings for all known origins at install/update
+  const stored = await getFromSyncStorage([STORAGE_KEY]);
+  const settingsByOrigin = stored[STORAGE_KEY] || {};
+  const origins = Object.keys(settingsByOrigin);
+  for (const origin of origins) {
+    await applySavedSettingsForOrigin(origin);
+  }
+});

--- a/site-settings-manager/manifest.json
+++ b/site-settings-manager/manifest.json
@@ -1,0 +1,21 @@
+{
+  "manifest_version": 3,
+  "name": "Site Settings Manager",
+  "version": "0.1.0",
+  "description": "Remember and reapply site permissions (camera, microphone, geolocation, notifications) per site.",
+  "permissions": [
+    "contentSettings",
+    "storage",
+    "tabs"
+  ],
+  "host_permissions": [
+    "<all_urls>"
+  ],
+  "action": {
+    "default_title": "Site Settings Manager",
+    "default_popup": "popup.html"
+  },
+  "background": {
+    "service_worker": "background.js"
+  }
+}

--- a/site-settings-manager/popup.html
+++ b/site-settings-manager/popup.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Site Settings Manager</title>
+    <style>
+      body { font-family: system-ui, sans-serif; margin: 12px; width: 320px; }
+      h1 { font-size: 16px; margin: 0 0 8px; }
+      .origin { font-size: 12px; color: #555; margin-bottom: 12px; word-break: break-all; }
+      .row { display: flex; align-items: center; justify-content: space-between; margin: 6px 0; }
+      label { font-size: 13px; }
+      select { font-size: 13px; }
+      .buttons { display: flex; gap: 8px; margin-top: 12px; }
+      .status { margin-top: 8px; font-size: 12px; color: #0a0; }
+      .error { color: #a00; }
+    </style>
+  </head>
+  <body>
+    <h1>Site Settings</h1>
+    <div id="origin" class="origin"></div>
+
+    <div class="row">
+      <label for="camera">Camera</label>
+      <select id="camera">
+        <option value="">No change</option>
+        <option value="allow">Allow</option>
+        <option value="block">Block</option>
+      </select>
+    </div>
+
+    <div class="row">
+      <label for="microphone">Microphone</label>
+      <select id="microphone">
+        <option value="">No change</option>
+        <option value="allow">Allow</option>
+        <option value="block">Block</option>
+      </select>
+    </div>
+
+    <div class="row">
+      <label for="geolocation">Location</label>
+      <select id="geolocation">
+        <option value="">No change</option>
+        <option value="allow">Allow</option>
+        <option value="block">Block</option>
+      </select>
+    </div>
+
+    <div class="row">
+      <label for="notifications">Notifications</label>
+      <select id="notifications">
+        <option value="">No change</option>
+        <option value="allow">Allow</option>
+        <option value="block">Block</option>
+      </select>
+    </div>
+
+    <div class="buttons">
+      <button id="saveApply">Save & Apply</button>
+      <button id="forget">Forget</button>
+    </div>
+
+    <div id="status" class="status"></div>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/site-settings-manager/popup.js
+++ b/site-settings-manager/popup.js
@@ -1,0 +1,148 @@
+/* eslint-disable no-undef */
+
+const SUPPORTED_CONTENT_TYPES = ["camera", "microphone", "geolocation", "notifications"];
+const STORAGE_KEY = "settingsByOrigin";
+
+function getOriginFromUrl(urlString) {
+  try {
+    const url = new URL(urlString);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    return url.origin;
+  } catch (e) {
+    return null;
+  }
+}
+
+function getPrimaryPatternForOrigin(origin) {
+  return `${origin}/*`;
+}
+
+function queryActiveTab() {
+  return new Promise((resolve) => {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      resolve(tabs && tabs[0] ? tabs[0] : null);
+    });
+  });
+}
+
+function getContentSetting(type, primaryUrl) {
+  return new Promise((resolve) => {
+    try {
+      chrome.contentSettings[type].get({ primaryUrl }, (details) => {
+        if (chrome.runtime.lastError) {
+          resolve({ error: chrome.runtime.lastError.message });
+        } else {
+          resolve(details);
+        }
+      });
+    } catch (err) {
+      resolve({ error: String(err) });
+    }
+  });
+}
+
+function setContentSetting(type, primaryPattern, setting) {
+  return new Promise((resolve) => {
+    try {
+      chrome.contentSettings[type].set({ primaryPattern, setting, scope: "regular" }, () => {
+        if (chrome.runtime.lastError) {
+          resolve({ error: chrome.runtime.lastError.message });
+        } else {
+          resolve({ ok: true });
+        }
+      });
+    } catch (err) {
+      resolve({ error: String(err) });
+    }
+  });
+}
+
+async function getFromSyncStorage(keys) {
+  return new Promise((resolve) => chrome.storage.sync.get(keys, (items) => resolve(items)));
+}
+
+async function setInSyncStorage(obj) {
+  return new Promise((resolve) => chrome.storage.sync.set(obj, () => resolve()));
+}
+
+async function removeFromSyncStorage(key) {
+  return new Promise((resolve) => chrome.storage.sync.remove(key, () => resolve()));
+}
+
+async function init() {
+  const statusEl = document.getElementById("status");
+  const originEl = document.getElementById("origin");
+  const tab = await queryActiveTab();
+  if (!tab || !tab.url) {
+    originEl.textContent = "No active tab URL";
+    return;
+  }
+  const origin = getOriginFromUrl(tab.url);
+  if (!origin) {
+    originEl.textContent = "Unsupported URL";
+    return;
+  }
+  originEl.textContent = origin;
+
+  // Load current effective settings from Chrome
+  for (const type of SUPPORTED_CONTENT_TYPES) {
+    const details = await getContentSetting(type, tab.url);
+    const select = document.getElementById(type);
+    if (!select) continue;
+    if (details && details.setting && (details.setting === "allow" || details.setting === "block")) {
+      select.value = details.setting;
+    } else {
+      select.value = ""; // No change
+    }
+  }
+
+  // Save & Apply
+  document.getElementById("saveApply").addEventListener("click", async () => {
+    statusEl.textContent = "";
+
+    // Build payload of selected settings
+    const payload = {};
+    for (const type of SUPPORTED_CONTENT_TYPES) {
+      const select = document.getElementById(type);
+      const value = select ? select.value : "";
+      if (value === "allow" || value === "block") {
+        payload[type] = value;
+      }
+    }
+
+    // Persist to storage
+    const stored = await getFromSyncStorage([STORAGE_KEY]);
+    const settingsByOrigin = stored[STORAGE_KEY] || {};
+    settingsByOrigin[origin] = { ...(settingsByOrigin[origin] || {}), ...payload };
+    await setInSyncStorage({ [STORAGE_KEY]: settingsByOrigin });
+
+    // Apply rules immediately
+    const primaryPattern = getPrimaryPatternForOrigin(origin);
+    for (const [type, value] of Object.entries(payload)) {
+      const result = await setContentSetting(type, primaryPattern, value);
+      if (result.error) {
+        statusEl.textContent = `Error applying ${type}: ${result.error}`;
+        statusEl.classList.add("error");
+        return;
+      }
+    }
+
+    statusEl.textContent = "Saved and applied.";
+    statusEl.classList.remove("error");
+  });
+
+  // Forget saved settings for this origin (does not change Chrome settings, just forgets our stored rules)
+  document.getElementById("forget").addEventListener("click", async () => {
+    statusEl.textContent = "";
+    const stored = await getFromSyncStorage([STORAGE_KEY]);
+    const settingsByOrigin = stored[STORAGE_KEY] || {};
+    if (settingsByOrigin[origin]) {
+      delete settingsByOrigin[origin];
+      await setInSyncStorage({ [STORAGE_KEY]: settingsByOrigin });
+    }
+    statusEl.textContent = "Forgot saved rules for this site.";
+    statusEl.classList.remove("error");
+  });
+}
+
+document.addEventListener("DOMContentLoaded", init);


### PR DESCRIPTION
Adds a Chrome extension to remember and reapply per-origin site permissions like camera and microphone.

---
<a href="https://cursor.com/background-agent?bcId=bc-ecfcef45-30d6-4582-8320-aa1fa9cc9e59">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ecfcef45-30d6-4582-8320-aa1fa9cc9e59">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

