### PR TITLE
Fix geolocation error and popup UI

### DIFF
--- a/site-settings-manager/popup.html
+++ b/site-settings-manager/popup.html
@@ -4,55 +4,152 @@
     <meta charset="utf-8" />
     <title>Site Settings Manager</title>
     <style>
-      body { font-family: system-ui, sans-serif; margin: 12px; width: 320px; }
-      h1 { font-size: 16px; margin: 0 0 8px; }
-      .origin { font-size: 12px; color: #555; margin-bottom: 12px; word-break: break-all; }
-      .row { display: flex; align-items: center; justify-content: space-between; margin: 6px 0; }
+      :root {
+        color-scheme: light dark;
+        --bg: #ffffff;
+        --fg: #111111;
+        --muted: #6b7280;
+        --border: #e5e7eb;
+        --accent: #2563eb;
+        --accent-contrast: #ffffff;
+        --error: #b91c1c;
+        --success: #065f46;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0b0f19;
+          --fg: #e5e7eb;
+          --muted: #9ca3af;
+          --border: #1f2937;
+          --accent: #3b82f6;
+          --accent-contrast: #0b0f19;
+          --error: #f87171;
+          --success: #34d399;
+        }
+      }
+
+      * { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+        background: var(--bg);
+        color: var(--fg);
+        width: 340px;
+        padding: 14px;
+      }
+
+      h1 {
+        font-size: 14px;
+        margin: 0 0 8px;
+        font-weight: 600;
+      }
+
+      .origin {
+        font-size: 12px;
+        color: var(--muted);
+        margin-bottom: 12px;
+        word-break: break-all;
+      }
+
+      .card {
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        padding: 10px;
+        background: transparent;
+      }
+
+      .row {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        align-items: center;
+        gap: 12px;
+        padding: 6px 0;
+      }
+      .row + .row { border-top: 1px dashed var(--border); }
+
       label { font-size: 13px; }
-      select { font-size: 13px; }
-      .buttons { display: flex; gap: 8px; margin-top: 12px; }
-      .status { margin-top: 8px; font-size: 12px; color: #0a0; }
-      .error { color: #a00; }
+
+      select {
+        font-size: 13px;
+        padding: 6px 8px;
+        border-radius: 8px;
+        border: 1px solid var(--border);
+        background: transparent;
+        color: var(--fg);
+      }
+      select:focus { outline: 2px solid var(--accent); outline-offset: 1px; }
+      select:disabled { opacity: 0.6; }
+
+      .buttons {
+        display: flex;
+        gap: 8px;
+        margin-top: 12px;
+      }
+
+      button {
+        appearance: none;
+        border: 1px solid var(--border);
+        background: var(--accent);
+        color: var(--accent-contrast);
+        padding: 8px 10px;
+        border-radius: 8px;
+        font-size: 13px;
+        cursor: pointer;
+      }
+      button#forget {
+        background: transparent;
+        color: var(--fg);
+      }
+      button:hover { filter: brightness(1.05); }
+
+      .status {
+        margin-top: 10px;
+        font-size: 12px;
+        color: var(--success);
+      }
+      .status.error { color: var(--error); }
     </style>
   </head>
   <body>
     <h1>Site Settings</h1>
     <div id="origin" class="origin"></div>
 
-    <div class="row">
-      <label for="camera">Camera</label>
-      <select id="camera">
-        <option value="">No change</option>
-        <option value="allow">Allow</option>
-        <option value="block">Block</option>
-      </select>
-    </div>
+    <div class="card">
+      <div class="row">
+        <label for="camera">Camera</label>
+        <select id="camera">
+          <option value="">No change</option>
+          <option value="allow">Allow</option>
+          <option value="block">Block</option>
+        </select>
+      </div>
 
-    <div class="row">
-      <label for="microphone">Microphone</label>
-      <select id="microphone">
-        <option value="">No change</option>
-        <option value="allow">Allow</option>
-        <option value="block">Block</option>
-      </select>
-    </div>
+      <div class="row">
+        <label for="microphone">Microphone</label>
+        <select id="microphone">
+          <option value="">No change</option>
+          <option value="allow">Allow</option>
+          <option value="block">Block</option>
+        </select>
+      </div>
 
-    <div class="row">
-      <label for="geolocation">Location</label>
-      <select id="geolocation">
-        <option value="">No change</option>
-        <option value="allow">Allow</option>
-        <option value="block">Block</option>
-      </select>
-    </div>
+      <div class="row">
+        <label for="geolocation">Location</label>
+        <select id="geolocation">
+          <option value="">No change</option>
+          <option value="allow">Allow</option>
+          <option value="block">Block</option>
+        </select>
+      </div>
 
-    <div class="row">
-      <label for="notifications">Notifications</label>
-      <select id="notifications">
-        <option value="">No change</option>
-        <option value="allow">Allow</option>
-        <option value="block">Block</option>
-      </select>
+      <div class="row">
+        <label for="notifications">Notifications</label>
+        <select id="notifications">
+          <option value="">No change</option>
+          <option value="allow">Allow</option>
+          <option value="block">Block</option>
+        </select>
+      </div>
     </div>
 
     <div class="buttons">


### PR DESCRIPTION
Fixes `TypeError` when applying geolocation settings and improves the popup UI styling.

The `TypeError` occurred because `chrome.contentSettings.geolocation` could be `undefined` in some browser environments. This PR introduces a robust check (`resolveContentSettingsKey`) to ensure `.set()` is only called on supported content settings, disabling unsupported options in the UI. The UI is also updated for a cleaner, more modern appearance.

---
<a href="https://cursor.com/background-agent?bcId=bc-0a3fa923-3d1e-4374-9859-42d8497c1551">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0a3fa923-3d1e-4374-9859-42d8497c1551">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

