### PR TITLE
Add Ultron Developments attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # remembersitehistory
 Remember my site permission history. 
+
+Built with love by [Ultron Developments](https://ultrondevelopments.com.au/).
+
+Report issues: use the extension's "Report issue" button or email `ultrondevelopments@gmail.com`.

--- a/site-settings-manager/README.md
+++ b/site-settings-manager/README.md
@@ -28,3 +28,11 @@ Remembers and reapplies site permissions (camera, microphone, geolocation, notif
 - There is no API to list all site settings across all sites. The extension captures rules as you visit sites and as you Save them in the popup.
 - Incognito windows are not handled specially. You can add handling using `scope: "incognito_session_only"` if desired.
 - The available `setting` values vary per content type. This extension uses `allow`/`block`, which are supported for the targeted types.
+
+## Attribution
+
+Built with love by [Ultron Developments](https://ultrondevelopments.com.au/).
+
+## Report issues
+
+Use the "Report issue" button in the popup or email `ultrondevelopments@gmail.com` with details about the site, steps to reproduce, and any screenshots.

--- a/site-settings-manager/manifest.json
+++ b/site-settings-manager/manifest.json
@@ -17,5 +17,7 @@
   },
   "background": {
     "service_worker": "background.js"
-  }
+  },
+  "homepage_url": "https://ultrondevelopments.com.au/",
+  "author": "Ultron Developments"
 }

--- a/site-settings-manager/popup.html
+++ b/site-settings-manager/popup.html
@@ -108,6 +108,15 @@
         color: var(--success);
       }
       .status.error { color: var(--error); }
+      .footer {
+        margin-top: 12px;
+        font-size: 11px;
+        color: var(--muted);
+        text-align: center;
+        border-top: 1px dashed var(--border);
+        padding-top: 8px;
+      }
+      .footer a { color: inherit; text-decoration: underline; }
     </style>
   </head>
   <body>
@@ -158,6 +167,7 @@
     </div>
 
     <div id="status" class="status"></div>
+    <div class="footer">Built with love by <a href="https://ultrondevelopments.com.au/" target="_blank" rel="noopener noreferrer">Ultron Developments</a></div>
     <script src="popup.js"></script>
   </body>
 </html>

--- a/site-settings-manager/popup.html
+++ b/site-settings-manager/popup.html
@@ -164,6 +164,7 @@
     <div class="buttons">
       <button id="saveApply">Save & Apply</button>
       <button id="forget">Forget</button>
+      <button id="reportIssue" title="Email Ultron Developments about a problem">Report issue</button>
     </div>
 
     <div id="status" class="status"></div>

--- a/site-settings-manager/popup.js
+++ b/site-settings-manager/popup.js
@@ -168,6 +168,34 @@ async function init() {
     }
     statusEl.textContent = "Forgot saved rules for this site.";
   });
+
+  // Report issue via email
+  const reportIssueButton = document.getElementById("reportIssue");
+  if (reportIssueButton) {
+    reportIssueButton.addEventListener("click", () => {
+      const manifest = (chrome?.runtime?.getManifest && chrome.runtime.getManifest()) || {};
+      const version = manifest.version || "unknown";
+
+      const subject = encodeURIComponent("Site Settings Manager: Issue report");
+      const selections = SUPPORTED_CONTENT_TYPES.map((type) => {
+        const select = document.getElementById(type);
+        const value = select ? (select.value || "no change") : "n/a";
+        return `- ${type}: ${value}`;
+      }).join("\n");
+
+      const body = encodeURIComponent([
+        "Describe the issue here:",
+        "",
+        `Origin: ${origin}`,
+        `Extension version: ${version}`,
+        "",
+        "Current selections:",
+        selections,
+      ].join("\n"));
+
+      window.open(`mailto:ultrondevelopments@gmail.com?subject=${subject}&body=${body}`);
+    });
+  }
 }
 
 document.addEventListener("DOMContentLoaded", init);


### PR DESCRIPTION
Add attribution to Ultron Developments in the UI, manifest, and README.

---
<a href="https://cursor.com/background-agent?bcId=bc-116dc839-24e0-4655-b42d-a205425a9466">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-116dc839-24e0-4655-b42d-a205425a9466">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

